### PR TITLE
Fix and improve on error

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/clanhr-api "0.1.0"
+(defproject clanhr/clanhr-api "0.1.1"
   :description "Raw clojure interface to ClanHR's APIs"
   :url "https://github.com/clanhr/clanhr-api"
   :dependencies [[org.clojure/clojure "1.7.0"]

--- a/src/clanhr_api/core.clj
+++ b/src/clanhr_api/core.clj
@@ -53,13 +53,14 @@
         (do
           (track-api-response data
             {:status 408
+             :error (str "Error getting " (:url data))
              :request-time (-> data :http-opts :request-timeout)
              :body {:message "Timed out"}}))
       (instance? clojure.lang.ExceptionInfo response)
         (do
           (track-api-response data
             {:status (.getMessage response)
-             :data (.getData response)
+             :error (str "Error getting " (:url data))
              :request-time (:request-time (.getData response))
              :body (json/parse-string (slurp (:body (.getData response))) true)}))
       (instance? Throwable response)


### PR DESCRIPTION
When aleph returned an error, also returned aleph objects that were being sent
back and we were getting an error while serializeing them. I removed that
extra data and also add some more useful information.
