### PR TITLE
Improve naming

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/clanhr-api "0.1.1"
+(defproject clanhr/clanhr-api "1.0.0"
   :description "Raw clojure interface to ClanHR's APIs"
   :url "https://github.com/clanhr/clanhr-api"
   :dependencies [[org.clojure/clojure "1.7.0"]

--- a/src/clanhr_api/core.clj
+++ b/src/clanhr_api/core.clj
@@ -58,10 +58,10 @@
       (instance? clojure.lang.ExceptionInfo response)
         (do
           (track-api-response data
-            {:status (.getMessage response)
-             :error (str "Error getting " (:url data))
-             :request-time (:request-time (.getData response))
-             :data (json/parse-string (slurp (:body (.getData response))) true)}))
+            (merge {:status (.getMessage response)
+                    :error (str "Error getting " (:url data))
+                    :request-time (:request-time (.getData response))}
+                   (json/parse-string (slurp (:body (.getData response))) true))))
       (instance? Throwable response)
         response
       :else

--- a/src/clanhr_api/core.clj
+++ b/src/clanhr_api/core.clj
@@ -38,9 +38,8 @@
   [data response]
   (try
     (track-api-response data response)
-    (-> response
-        (assoc :status (:status response))
-        (assoc :body-data (json/parse-string (slurp (:body response)) true)))
+    (merge {:status (:status response)}
+           (json/parse-string (slurp (:body response)) true))
     (catch Exception e
       (errors/exception e))))
 
@@ -55,14 +54,14 @@
             {:status 408
              :error (str "Error getting " (:url data))
              :request-time (-> data :http-opts :request-timeout)
-             :body-data {:message "Timed out"}}))
+             :data {:message "Timed out"}}))
       (instance? clojure.lang.ExceptionInfo response)
         (do
           (track-api-response data
             {:status (.getMessage response)
              :error (str "Error getting " (:url data))
              :request-time (:request-time (.getData response))
-             :body-data (json/parse-string (slurp (:body (.getData response))) true)}))
+             :data (json/parse-string (slurp (:body (.getData response))) true)}))
       (instance? Throwable response)
         response
       :else

--- a/src/clanhr_api/core.clj
+++ b/src/clanhr_api/core.clj
@@ -40,7 +40,7 @@
     (track-api-response data response)
     (-> response
         (assoc :status (:status response))
-        (assoc :data (json/parse-string (slurp (:body response)) true)))
+        (assoc :body-data (json/parse-string (slurp (:body response)) true)))
     (catch Exception e
       (errors/exception e))))
 
@@ -55,20 +55,20 @@
             {:status 408
              :error (str "Error getting " (:url data))
              :request-time (-> data :http-opts :request-timeout)
-             :body {:message "Timed out"}}))
+             :body-data {:message "Timed out"}}))
       (instance? clojure.lang.ExceptionInfo response)
         (do
           (track-api-response data
             {:status (.getMessage response)
              :error (str "Error getting " (:url data))
              :request-time (:request-time (.getData response))
-             :body (json/parse-string (slurp (:body (.getData response))) true)}))
+             :body-data (json/parse-string (slurp (:body (.getData response))) true)}))
       (instance? Throwable response)
         response
       :else
         (-> response
             (assoc :status (-> response :data :cause))
-            (assoc :data (slurp (-> response :data :body)))))
+            (assoc :body-data (slurp (-> response :data :body)))))
     (catch Exception e
       (errors/exception e))))
 

--- a/test/clanhr_api/core_test.clj
+++ b/test/clanhr_api/core_test.clj
@@ -10,7 +10,7 @@
   (let [result-ch (clanhr-api/http-get {:service service-key :path "/"})]
     (is result-ch)
     (let [result (<!! result-ch)
-          data (:data result)]
+          data (:body-data result)]
       (is (result/succeeded? result))
       (is data)
       (is (= 200 (:status result)))
@@ -30,4 +30,4 @@
                                            :body {:email "donbonifacio@gmail.com"
                                                   :password "wazabi"}}))]
     (result/failed? result)
-    (is (= "invalid-email-or-password" (first (-> result :body :errors))))))
+    (is (= "invalid-email-or-password" (first (-> result :body-data :errors))))))

--- a/test/clanhr_api/core_test.clj
+++ b/test/clanhr_api/core_test.clj
@@ -9,12 +9,10 @@
   [service-key expected-name]
   (let [result-ch (clanhr-api/http-get {:service service-key :path "/"})]
     (is result-ch)
-    (let [result (<!! result-ch)
-          data (:body-data result)]
+    (let [result (<!! result-ch)]
       (is (result/succeeded? result))
-      (is data)
       (is (= 200 (:status result)))
-      (is (= (:name data) expected-name)))))
+      (is (= (:name result) expected-name)))))
 
 (deftest apis-home
   (test-api-home :directory-api "ClanHR Directory API")
@@ -30,4 +28,4 @@
                                            :body {:email "donbonifacio@gmail.com"
                                                   :password "wazabi"}}))]
     (result/failed? result)
-    (is (= "invalid-email-or-password" (first (-> result :body-data :errors))))))
+    (is (= "invalid-email-or-password" (first (-> result :data :errors))))))

--- a/test/clanhr_api/core_test.clj
+++ b/test/clanhr_api/core_test.clj
@@ -28,4 +28,4 @@
                                            :body {:email "donbonifacio@gmail.com"
                                                   :password "wazabi"}}))]
     (result/failed? result)
-    (is (= "invalid-email-or-password" (first (-> result :data :errors))))))
+    (is (= "invalid-email-or-password" (first (-> result :errors))))))


### PR DESCRIPTION
Usually we user the `:data` key for results, but this compoenent returns
an http response with a result, meaning that we had `:data -> :data`
struture.

Changes the base data to `:body-data` to prevent this.
