### PR TITLE
Mothership on localhost bypass

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/clanhr-api "1.2.0"
+(defproject clanhr/clanhr-api "1.3.0"
   :description "Raw clojure interface to ClanHR's APIs"
   :url "https://github.com/clanhr/clanhr-api"
   :dependencies [[org.clojure/clojure "1.7.0"]

--- a/test/clanhr_api/core_test.clj
+++ b/test/clanhr_api/core_test.clj
@@ -38,3 +38,16 @@
                                           :http-opts {:connection-timeout 1}}))]
     (is (result/failed? result))
     (is (= 1 (:requests result)))))
+
+(deftest mothership-bypass-test
+  (testing "defaults to remote service"
+    (let [data (clanhr-api/setup {:service :directory-api})]
+      (is (= 80 (clanhr-api/service-port data)))
+      (is (= "http://directory.api.staging.clanhr.com" (clanhr-api/service-host data)))))
+
+  (testing "local mothership override"
+    (let [data {:mothership? true
+                :service :directory-api
+                :clanhr-directory-api-port 5000}]
+      (is (= 5000 (clanhr-api/service-port data)))
+      (is (= "http://localhost:5000" (clanhr-api/service-host data))))))


### PR DESCRIPTION
If we are running a mothership on the same machine, now with a
`CLANHR_MOTHERSHIP=true` the component will use the services on
localhost.
