### PR TITLE
Improve exception logging

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/clanhr-api "1.4.0"
+(defproject clanhr/clanhr-api "1.5.0"
   :description "Raw clojure interface to ClanHR's APIs"
   :url "https://github.com/clanhr/clanhr-api"
   :dependencies [[org.clojure/clojure "1.7.0"]


### PR DESCRIPTION
When we get an exception from aleph, we log it on bugsnag as is, and we
don't have any useful information. We get something like:

```
clojure.lang.ExceptionInfo: status: 500
  at clojure.core/ex-info(core.clj:4616)
  at clojure.core/ex-info(core.clj:4616)
  at aleph.http.client-middleware/wrap-exceptions[fn](client_middleware.clj:167)
  at manifold.deferred/chain-(deferred.clj:815)
```

We don't have a proper stack trace, the cause, why we had the exception
or where it was. I refactored the code to register an exception with
more information, like a specific error message, status and response.
