### PR TITLE
Add more info to exceptions

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/clanhr-api "1.7.2"
+(defproject clanhr/clanhr-api "1.7.3"
   :description "Raw clojure interface to ClanHR's APIs"
   :url "https://github.com/clanhr/clanhr-api"
   :dependencies.edn "https://raw.githubusercontent.com/clanhr/dependencies/master/dependencies.edn"

--- a/src/clanhr_api/core.clj
+++ b/src/clanhr_api/core.clj
@@ -75,7 +75,8 @@
           (register-exception response info)
           (track-api-response data info))
       (instance? Throwable response)
-        (let [info {:error (str "Error getting " (:url data))}]
+        (let [info {:error (str "Error getting " (:url data))
+                    :caused-by response}]
           (register-exception response info)
           response)
       :else


### PR DESCRIPTION
When a generic exceptions is caught on the core, it's wrapped on an
ex-info. The problem is that that inner exceptions is lost on the way to
bugsnag, and we end up not having that information.

Added the source exception as a field.

Closes https://github.com/clanhr/mothership/issues/1259
Closes https://github.com/clanhr/mothership/issues/1260
