### PR TITLE
Properly handle 4xx results

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/clanhr-api "1.7.4"
+(defproject clanhr/clanhr-api "1.8.0"
   :description "Raw clojure interface to ClanHR's APIs"
   :url "https://github.com/clanhr/clanhr-api"
   :dependencies [[org.clojure/clojure "1.8.0"]


### PR DESCRIPTION
Motivation:

A service might request something and get, for example, a 408 payment
required error. At this moment, aleph will throw an exception and we
will log it. But we don't really want that. We want to short circuit and
return the error that we got.

Modifications:

Add `:throw-exceptions? false` to aleph config.

Result:

We don't get an exception, but the actual request. After that we try to
infer the success based on the response status code.
