### PR TITLE
Add request-time to response

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/clanhr-api "1.8.0"
+(defproject clanhr/clanhr-api "1.9.0"
   :description "Raw clojure interface to ClanHR's APIs"
   :url "https://github.com/clanhr/clanhr-api"
   :dependencies [[org.clojure/clojure "1.8.0"]

--- a/test/clanhr_api/core_test.clj
+++ b/test/clanhr_api/core_test.clj
@@ -13,6 +13,7 @@
       (is (result/succeeded? result))
       (is (= 200 (:status result)))
       (is (= 1 (:requests result)))
+      (is (:request-time result))
       (is (= (:name result) expected-name)))))
 
 (deftest apis-home


### PR DESCRIPTION
Motivation:
  We are having some problems related with request-times.

Modifications:
  Throws an error to bugsnag when the request-time is bigger than
  `maximum-accepted-request-time` ms.

ref: https://github.com/clanhr/mothership/issues/1429
