### PR TITLE
Better json parsing error handling

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/clanhr-api "1.10.1"
+(defproject clanhr/clanhr-api "1.11.0"
   :description "Raw clojure interface to ClanHR's APIs"
   :url "https://github.com/clanhr/clanhr-api"
   :dependencies [[org.clojure/clojure "1.8.0"]

--- a/src/clanhr_api/core.clj
+++ b/src/clanhr_api/core.clj
@@ -56,7 +56,16 @@
   [response]
   (let [first-char (-> response :status str first)]
     (or (= \2 first-char)
-        (= \3 first-char) )))
+        (= \3 first-char))))
+
+(defn- parse-response
+  "Parses the response body"
+  [response]
+  (let [body (slurp (:body response))]
+    (try
+      (json/parse-string body true)
+      (catch Exception ex
+        (throw (Exception. (str "Error parsing json: '" body "'")))))))
 
 (defn- prepare-response
   "Handles post-response"
@@ -67,7 +76,7 @@
             :success (get-success response)
             :request-time (:request-time response)
             :requests (inc (:requests data))}
-           (json/parse-string (slurp (:body response)) true))
+           (parse-response response))
     (catch Exception e
       (errors/exception e))))
 

--- a/test/clanhr_api/core_test.clj
+++ b/test/clanhr_api/core_test.clj
@@ -36,7 +36,7 @@
 (deftest test-timeout
   (let [result (<!! (clanhr-api/http-get {:service :directory-api :path "/"
                                           :retries 1
-                                          :http-opts {:connection-timeout 1}}))]
+                                          :http-opts {:request-timeout 1}}))]
     (is (result/failed? result))
     (is (= 1 (:requests result)))))
 


### PR DESCRIPTION
When a response isn't json, return a better error, showing the bad body.